### PR TITLE
Update pressure sensor type configuration to pressure2

### DIFF
--- a/deployment/config/config.json
+++ b/deployment/config/config.json
@@ -30,7 +30,7 @@
         "debug": false,
         "value": "",
         "active": true,
-        "type": "pressure"
+        "type": "pressure2"
       },
       {
         "name": "2",
@@ -38,7 +38,7 @@
         "debug": false,
         "value": "",
         "active": true,
-        "type": "pressure"
+        "type": "pressure2"
       },
       {
         "name": "3",
@@ -47,7 +47,7 @@
         "frequency": 20,
         "value": "",
         "active": true,
-        "type": "pressure"
+        "type": "pressure2"
       },
       {
         "name": "Flow",


### PR DESCRIPTION
## Summary
Updated the sensor type configuration for pressure sensors from "pressure" to "pressure2" in the deployment configuration file.

## Changes
- Changed sensor type from "pressure" to "pressure2" for three pressure sensor entries (sensors 1, 2, and 3)
- Updated configuration entries at lines 33, 41, and 50 in `deployment/config/config.json`

## Details
This change updates the type identifier used for pressure sensors in the deployment configuration. All three pressure sensor entries now reference the "pressure2" type instead of "pressure", likely to support a new sensor model or updated sensor driver implementation.

https://claude.ai/code/session_01SXWC8SJShcHD92GvFoPt5P