### PR TITLE
feat: add configurable VFD Modbus TCP support

### DIFF
--- a/deployment/config/config.json
+++ b/deployment/config/config.json
@@ -66,7 +66,14 @@
       "name": "vfd1",
       "address": "5",
       "debug": false,
-      "frequency": 20
+      "frequency": 20,
+      "transport": "serial",
+      "dry_run": false,
+      "timeout": 2.0,
+      "tcp": {
+        "host": "",
+        "port": 502
+      }
     },
   
     "valves": [

--- a/deployment/config/config1-d.json
+++ b/deployment/config/config1-d.json
@@ -67,7 +67,14 @@
     "name": "vfd1",
     "address": "5",
     "debug": false,
-    "frequency": 20
+    "frequency": 20,
+    "transport": "serial",
+    "dry_run": false,
+    "timeout": 2.0,
+    "tcp": {
+      "host": "",
+      "port": 502
+    }
   },
 
   "valves": [

--- a/deployment/config/config1-site-b.json
+++ b/deployment/config/config1-site-b.json
@@ -70,7 +70,14 @@
     "name": "vfd1",
     "address": "12",
     "debug": false,
-    "frequency": 20
+    "frequency": 20,
+    "transport": "serial",
+    "dry_run": false,
+    "timeout": 2.0,
+    "tcp": {
+      "host": "",
+      "port": 502
+    }
   },
 
   "valves": [

--- a/deployment/config/config1.json
+++ b/deployment/config/config1.json
@@ -67,7 +67,14 @@
     "name": "vfd1",
     "address": "5",
     "debug": false,
-    "frequency": 20
+    "frequency": 20,
+    "transport": "serial",
+    "dry_run": false,
+    "timeout": 2.0,
+    "tcp": {
+      "host": "",
+      "port": 502
+    }
   },
 
   "valves": [

--- a/deployment/config/config2-d.json
+++ b/deployment/config/config2-d.json
@@ -54,7 +54,14 @@
     "name": "vfd2",
     "address": "5",
     "debug": false,
-    "frequency": 20
+    "frequency": 20,
+    "transport": "serial",
+    "dry_run": false,
+    "timeout": 2.0,
+    "tcp": {
+      "host": "",
+      "port": 502
+    }
   },
   "valves": [
     {

--- a/deployment/config/config2-test.json
+++ b/deployment/config/config2-test.json
@@ -57,7 +57,14 @@
     "name": "vfd2",
     "address": "5",
     "debug": false,
-    "frequency": 20
+    "frequency": 20,
+    "transport": "serial",
+    "dry_run": false,
+    "timeout": 2.0,
+    "tcp": {
+      "host": "",
+      "port": 502
+    }
   },
   "valves": [
     {

--- a/deployment/config/config2.json
+++ b/deployment/config/config2.json
@@ -56,7 +56,14 @@
     "name": "vfd2",
     "address": "5",
     "debug": false,
-    "frequency": 20
+    "frequency": 20,
+    "transport": "serial",
+    "dry_run": false,
+    "timeout": 2.0,
+    "tcp": {
+      "host": "",
+      "port": 502
+    }
   },
   "valves": [
     {

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,77 @@
 | Clear Buffers Before Each Transaction | true | true | Same |
 | Close Port After Each Call | true | true | Same |
 
+## Delta C2000 Plus VFD Configuration
+
+The serial service can control the VFD over either Modbus RTU or Modbus TCP.
+The MQTT command topics stay the same; only the `vfd` config block chooses the
+transport.
+
+### Serial RS-485 example
+
+```json
+{
+  "serial": {
+    "port": "/dev/ttyACM0",
+    "baudrate": 9600,
+    "bytesize": 8,
+    "parity": "PARITY_NONE",
+    "stopbits": 1,
+    "timeout": 0.05,
+    "mode": "MODE_RTU",
+    "clear_buffers_before_each_transaction": true,
+    "close_port_after_each_call": true
+  },
+  "vfd": {
+    "name": "vfd1",
+    "address": "5",
+    "transport": "serial",
+    "dry_run": false,
+    "timeout": 2.0,
+    "frequency": 20,
+    "tcp": {
+      "host": "",
+      "port": 502
+    }
+  }
+}
+```
+
+For RS-485 control, configure the Delta C2000 Plus parameters:
+
+- `00-20 = 1` for frequency command from RS-485
+- `00-21 = 2` for operation command from RS-485
+
+### TCP/IP example
+
+```json
+{
+  "vfd": {
+    "name": "vfd1",
+    "address": "5",
+    "transport": "tcp",
+    "dry_run": false,
+    "timeout": 2.0,
+    "tcp": {
+      "host": "192.0.2.10",
+      "port": 502
+    }
+  }
+}
+```
+
+For Ethernet card control, configure the Delta C2000 Plus parameters:
+
+- `00-20 = 8` for frequency command from communication card
+- `00-21 = 5` for operation command from communication card
+- `09-75 = 0` for static IP or `09-75 = 1` for DHCP
+- `09-76..09-79` for IP address octets
+- `09-80..09-83` for subnet mask octets
+- `09-84..09-87` for gateway octets
+
+Software control is not a safety system. Use a physical emergency stop and
+proper VFD wiring, protection, and commissioning procedures.
+
 <div style="page-break-after: always;"></div>
 
 ## Pin Configuration

--- a/src/serial_service/tests/test_vfd_driver.py
+++ b/src/serial_service/tests/test_vfd_driver.py
@@ -1,0 +1,159 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from vfd_handler.vfd_driver import (
+    COMMAND_RUN_FORWARD,
+    COMMAND_RUN_REVERSE,
+    COMMAND_STOP,
+    REG_DC_BUS_VOLTAGE,
+    REG_FREQUENCY_COMMAND,
+    REG_OPERATION_COMMAND,
+    REG_OUTPUT_CURRENT,
+    REG_OUTPUT_FREQUENCY,
+    REG_OUTPUT_VOLTAGE,
+    ModbusTCPTransport,
+    VFDDriver,
+)
+
+
+class FakeTransport:
+    def __init__(self, reads=None):
+        self.reads = reads or {}
+        self.writes = []
+
+    def connect(self):
+        pass
+
+    def close(self):
+        pass
+
+    def read_register(self, address, count=1):
+        return self.reads[address]
+
+    def write_register(self, address, value):
+        self.writes.append((address, value))
+
+
+def test_set_frequency_hz_writes_scaled_value_for_5hz():
+    transport = FakeTransport()
+    driver = VFDDriver(transport)
+
+    driver.set_frequency_hz(5.0)
+
+    assert transport.writes == [(REG_FREQUENCY_COMMAND, 500)]
+
+
+def test_set_frequency_hz_writes_scaled_value_for_50hz():
+    transport = FakeTransport()
+    driver = VFDDriver(transport)
+
+    driver.set_frequency_hz(50.0)
+
+    assert transport.writes == [(REG_FREQUENCY_COMMAND, 5000)]
+
+
+def test_run_forward_writes_delta_forward_command():
+    transport = FakeTransport()
+    driver = VFDDriver(transport)
+
+    driver.run_forward()
+
+    assert transport.writes == [(REG_OPERATION_COMMAND, COMMAND_RUN_FORWARD)]
+
+
+def test_run_reverse_writes_delta_reverse_command():
+    transport = FakeTransport()
+    driver = VFDDriver(transport)
+
+    driver.run_reverse()
+
+    assert transport.writes == [(REG_OPERATION_COMMAND, COMMAND_RUN_REVERSE)]
+
+
+def test_stop_writes_delta_stop_command():
+    transport = FakeTransport()
+    driver = VFDDriver(transport)
+
+    driver.stop()
+
+    assert transport.writes == [(REG_OPERATION_COMMAND, COMMAND_STOP)]
+
+
+def test_read_output_frequency_hz_reads_monitor_and_scales_value():
+    transport = FakeTransport({REG_OUTPUT_FREQUENCY: 1234})
+    driver = VFDDriver(transport)
+
+    assert driver.read_output_frequency_hz() == 12.34
+
+
+def test_read_output_current_reads_current_register():
+    transport = FakeTransport({REG_OUTPUT_CURRENT: 42})
+    driver = VFDDriver(transport)
+
+    assert driver.read_output_current() == 42
+
+
+def test_read_dc_bus_voltage_reads_voltage_register():
+    transport = FakeTransport({REG_DC_BUS_VOLTAGE: 680})
+    driver = VFDDriver(transport)
+
+    assert driver.read_dc_bus_voltage() == 680
+
+
+def test_read_output_voltage_reads_output_voltage_register():
+    transport = FakeTransport({REG_OUTPUT_VOLTAGE: 220})
+    driver = VFDDriver(transport)
+
+    assert driver.read_output_voltage() == 220
+
+
+class FakeResponse:
+    def __init__(self, registers=None):
+        self.registers = registers or []
+
+    def isError(self):
+        return False
+
+
+class FakeTcpClient:
+    def __init__(self):
+        self.connected = False
+        self.connect_calls = 0
+        self.close_calls = 0
+        self.reads = []
+        self.writes = []
+
+    def connect(self):
+        self.connect_calls += 1
+        self.connected = True
+        return True
+
+    def close(self):
+        self.close_calls += 1
+        self.connected = False
+
+    def read_holding_registers(self, register, count=1, slave=1):
+        self.reads.append((register, count, slave))
+        return FakeResponse([123])
+
+    def write_register(self, register, value, device_id=1):
+        self.writes.append((register, value, device_id))
+        return FakeResponse()
+
+
+def test_tcp_transport_reuses_connection_across_operations():
+    client = FakeTcpClient()
+    transport = ModbusTCPTransport(host="192.0.2.10", port=502, unit_id=7, client=client)
+
+    transport.write_register(REG_OPERATION_COMMAND, COMMAND_RUN_FORWARD)
+    transport.read_register(REG_OUTPUT_FREQUENCY)
+    transport.write_register(REG_FREQUENCY_COMMAND, 500)
+
+    assert client.connect_calls == 1
+    assert client.writes == [
+        (REG_OPERATION_COMMAND, COMMAND_RUN_FORWARD, 7),
+        (REG_FREQUENCY_COMMAND, 500, 7),
+    ]
+    assert client.reads == [(REG_OUTPUT_FREQUENCY, 1, 7)]

--- a/src/serial_service/vfd_handler/vfd_driver.py
+++ b/src/serial_service/vfd_handler/vfd_driver.py
@@ -1,0 +1,260 @@
+import logging
+import os
+
+
+REG_OPERATION_COMMAND = 0x2000
+REG_FREQUENCY_COMMAND = 0x2001
+REG_FAULT_CODE = 0x2100
+REG_OPERATION_STATUS = 0x2101
+REG_FREQUENCY_COMMAND_MONITOR = 0x2102
+REG_OUTPUT_FREQUENCY = 0x2103
+REG_OUTPUT_CURRENT = 0x2104
+REG_DC_BUS_VOLTAGE = 0x2105
+REG_OUTPUT_VOLTAGE = 0x2106
+
+COMMAND_STOP = 0x0001
+COMMAND_RUN_FORWARD = 0x0012
+COMMAND_RUN_REVERSE = 0x0022
+
+READ_HOLDING_REGISTERS = 3
+WRITE_SINGLE_REGISTER = 6
+
+
+def _as_bool(value, default=False):
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+class ModbusRTUTransport:
+    """VFD transport adapter over the existing shared SerialCom bus."""
+
+    def __init__(self, modbus_com, unit_id, close_underlying=False):
+        if modbus_com is None:
+            raise ValueError("modbus_com is required for serial VFD transport")
+        self.modbus_com = modbus_com
+        self.unit_id = int(unit_id)
+        self.close_underlying = close_underlying
+
+    def connect(self):
+        """SerialCom opens the port lazily through minimalmodbus."""
+
+    def close(self):
+        if self.close_underlying:
+            self.modbus_com.close()
+
+    def read_register(self, address, count=1):
+        result = self.modbus_com.read_register(
+            self.unit_id,
+            address,
+            count,
+            READ_HOLDING_REGISTERS,
+        )
+        return _normalize_register_result(result, count)
+
+    def write_register(self, address, value):
+        self.modbus_com.write_register(
+            self.unit_id,
+            address,
+            int(value),
+            0,
+            WRITE_SINGLE_REGISTER,
+        )
+
+
+class ModbusTCPTransport:
+    """Persistent Modbus TCP transport for Delta C2000 Plus VFD control."""
+
+    def __init__(
+        self,
+        host,
+        port=502,
+        unit_id=1,
+        timeout=2.0,
+        client=None,
+        client_factory=None,
+    ):
+        if not host:
+            raise ValueError("host is required for TCP VFD transport")
+        self.host = host
+        self.port = int(port)
+        self.unit_id = int(unit_id)
+        self.timeout = float(timeout)
+        self.client = client or self._build_client(client_factory)
+
+    def _build_client(self, client_factory):
+        if client_factory is not None:
+            return client_factory(host=self.host, port=self.port, timeout=self.timeout)
+
+        from pymodbus.client import ModbusTcpClient
+
+        return ModbusTcpClient(host=self.host, port=self.port, timeout=self.timeout)
+
+    def connect(self):
+        if getattr(self.client, "connected", False):
+            return
+        if not self.client.connect():
+            raise ConnectionError(f"Failed to connect to VFD at {self.host}:{self.port}")
+
+    def close(self):
+        if getattr(self.client, "connected", False):
+            self.client.close()
+
+    def read_register(self, address, count=1):
+        self.connect()
+        try:
+            result = self.client.read_holding_registers(
+                address,
+                count=count,
+                slave=self.unit_id,
+            )
+        except Exception:
+            self.close()
+            raise
+        if result.isError():
+            self.close()
+            raise IOError(f"Failed to read VFD register {address}")
+        return _normalize_register_result(result.registers, count)
+
+    def write_register(self, address, value):
+        self.connect()
+        try:
+            result = self.client.write_register(
+                address,
+                int(value),
+                device_id=self.unit_id,
+            )
+        except TypeError:
+            result = self.client.write_register(
+                address,
+                int(value),
+                slave=self.unit_id,
+            )
+        except Exception:
+            self.close()
+            raise
+        if result.isError():
+            self.close()
+            raise IOError(f"Failed to write VFD register {address}")
+
+
+class DryRunTransport:
+    """No-hardware transport that logs control operations and returns zeros."""
+
+    def __init__(self, logger=None):
+        self.logger = logger or logging.getLogger(self.__class__.__name__)
+        self.writes = []
+
+    def connect(self):
+        self.logger.info("VFD dry-run transport connected")
+
+    def close(self):
+        self.logger.info("VFD dry-run transport closed")
+
+    def read_register(self, address, count=1):
+        self.logger.info("VFD dry-run read register %s count %s", address, count)
+        if count == 1:
+            return 0
+        return [0] * count
+
+    def write_register(self, address, value):
+        self.writes.append((address, int(value)))
+        self.logger.warning("VFD dry-run write register %s value %s", address, value)
+
+
+class VFDDriver:
+    """High-level Delta C2000 Plus VFD API independent of Modbus transport."""
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def connect(self):
+        self.transport.connect()
+
+    def close(self):
+        self.transport.close()
+
+    def read_register(self, address, count=1):
+        return self.transport.read_register(address, count)
+
+    def write_register(self, address, value):
+        self.transport.write_register(address, value)
+
+    def set_frequency_hz(self, hz):
+        scaled_hz = int(round(float(hz) * 100))
+        self.write_register(REG_FREQUENCY_COMMAND, scaled_hz)
+
+    def run_forward(self):
+        self.write_register(REG_OPERATION_COMMAND, COMMAND_RUN_FORWARD)
+
+    def run_reverse(self):
+        self.write_register(REG_OPERATION_COMMAND, COMMAND_RUN_REVERSE)
+
+    def stop(self):
+        self.write_register(REG_OPERATION_COMMAND, COMMAND_STOP)
+
+    def read_status(self):
+        return self.read_register(REG_OPERATION_STATUS)
+
+    def read_fault_code(self):
+        return self.read_register(REG_FAULT_CODE)
+
+    def read_output_frequency_hz(self):
+        return self.read_register(REG_OUTPUT_FREQUENCY) / 100.0
+
+    def read_output_current(self):
+        return self.read_register(REG_OUTPUT_CURRENT)
+
+    def read_dc_bus_voltage(self):
+        return self.read_register(REG_DC_BUS_VOLTAGE)
+
+    def read_output_voltage(self):
+        return self.read_register(REG_OUTPUT_VOLTAGE)
+
+
+def build_vfd_driver(config, serial_com=None, logger=None):
+    vfd_config = config.get("vfd", {})
+    unit_id = int(
+        vfd_config.get(
+            "unit_id",
+            vfd_config.get("address", os.getenv("VFD_UNIT_ID", 1)),
+        )
+    )
+    enabled = _as_bool(vfd_config.get("enabled", os.getenv("VFD_ENABLED")), True)
+    dry_run = _as_bool(vfd_config.get("dry_run", os.getenv("VFD_DRY_RUN")), False)
+
+    if not enabled or dry_run:
+        return VFDDriver(DryRunTransport(logger=logger))
+
+    transport_name = str(
+        vfd_config.get("transport", os.getenv("VFD_TRANSPORT", "serial"))
+    ).strip().lower()
+
+    if transport_name == "serial":
+        return VFDDriver(ModbusRTUTransport(serial_com, unit_id))
+    if transport_name == "tcp":
+        tcp_config = vfd_config.get("tcp", {})
+        host = tcp_config.get("host", os.getenv("VFD_TCP_HOST"))
+        port = tcp_config.get("port", os.getenv("VFD_TCP_PORT", 502))
+        timeout = tcp_config.get(
+            "timeout",
+            vfd_config.get("timeout", os.getenv("VFD_TIMEOUT_SECONDS", 2.0)),
+        )
+        return VFDDriver(
+            ModbusTCPTransport(
+                host=host,
+                port=port,
+                unit_id=unit_id,
+                timeout=timeout,
+            )
+        )
+
+    raise ValueError(f"Unsupported VFD transport: {transport_name}")
+
+
+def _normalize_register_result(result, count):
+    if count == 1 and isinstance(result, (list, tuple)):
+        return result[0]
+    return result

--- a/src/serial_service/vfd_handler/vfd_node.py
+++ b/src/serial_service/vfd_handler/vfd_node.py
@@ -5,23 +5,20 @@ import threading
 import paho.mqtt.client as mqtt
 
 from serial_com.serial_com import SerialCom
+from vfd_handler.vfd_driver import build_vfd_driver
 
 
 class VFDController:
-    def __init__(self, config_file, serial_com: SerialCom):
-        self.load_config(config_file)
+    def __init__(self, config_file, serial_com: SerialCom, vfd_driver=None):
+        self.config = self.load_config(config_file)
         self.serial_com = serial_com
-        self.startstopAddr = 8192
-        self.setFreqAddr = 8193
-        self.readFreqAddr = 8451
-        self.startCmd = 18
-        self.stopCmd = 1
-        self.startDec = 0
-        self.setFreqDec = 2
-        self.writeFC = 6
-        self.readFC = 3
 
         self.logger = self.setup_logger()
+        self.vfd_driver = vfd_driver or build_vfd_driver(
+            self.config,
+            serial_com=serial_com,
+            logger=self.logger,
+        )
 
         self.setup_mqtt()
 
@@ -47,6 +44,7 @@ class VFDController:
         self.broker_port = mqtt_config['broker_port']
         self.username = mqtt_config['username']
         self.password = mqtt_config['password']
+        return config
 
     def setup_mqtt(self):
         self.client = mqtt.Client()
@@ -93,36 +91,37 @@ class VFDController:
 
     def start_vfd(self):
         try:
-            self.serial_com.write_register(self.address,self.startstopAddr, self.startCmd, self.startDec, self.writeFC)
+            self.vfd_driver.run_forward()
         except Exception as e:
             self.logger.error(f"Ignored writing command: {e}")
 
-        self.logger.info("Started VFD.")
+        self.logger.info("VFD run_forward command sent.")
 
     def stop_vfd(self):
         try:
-            self.serial_com.write_register(self.address,self.startstopAddr, self.stopCmd, self.startDec, self.writeFC)
+            self.vfd_driver.stop()
         except Exception as e:
             self.logger.error(f"Ignored writing command: {e}")
 
-        self.logger.info("Stopped VFD.")
+        self.logger.info("VFD stop command sent.")
 
     def set_frequency(self, frequency):
         try:
-            self.serial_com.write_register(self.address,self.setFreqAddr, frequency, self.setFreqDec, self.writeFC)
+            self.vfd_driver.set_frequency_hz(frequency)
         except Exception as e:
             self.logger.error(f"Ignored writing command: {e}")
 
-        self.logger.info(f"Set frequency: {frequency}")
+        self.logger.info(f"Set VFD frequency command: {frequency} Hz")
 
     def emergency_stop(self):
         try:
-            self.serial_com.write_register(self.address,self.startstopAddr, self.stopCmd, self.startDec, self.writeFC)
+            self.vfd_driver.stop()
         except Exception as e:
             self.logger.error(f"Ignored writing command: {e}")
         while True:
+            speed = None
             try:
-                speed = self.serial_com.read_register(self.address,self.readFreqAddr, 2, self.readFC)
+                speed = self.vfd_driver.read_output_frequency_hz()
             except Exception as e:
                 self.logger.error(f"Ignored reading command: {e}")
             if speed == 0:
@@ -134,7 +133,7 @@ class VFDController:
     def publish_feedback(self):
         while True:
             try:
-                speed = self.serial_com.read_register(self.address,self.readFreqAddr, 2, self.readFC)
+                speed = self.vfd_driver.read_output_frequency_hz()
                 self.client.publish(f"{self.device_id}/vfd/feedback", speed)
             except Exception as e:
                 self.logger.error(f"Failed to read VFD feedback: {e}")
@@ -146,5 +145,3 @@ class VFDController:
         feedback_thread.start()
         while True:
             time.sleep(0.2)  # Keep the script running to handle MQTT messages
-
-


### PR DESCRIPTION
## Summary
  - Add transport-independent Delta C2000 Plus VFD driver
  - Support existing Modbus RTU serial control and new persistent Modbus TCP control
  - Add `vfd.transport`, `vfd.tcp.host`, `vfd.tcp.port`, `vfd.timeout`, and `vfd.dry_run` config keys
  - Keep existing MQTT VFD command topics unchanged
  - Add unit tests for register writes, monitor reads, and TCP connection reuse
  - Document serial/TCP setup and required Delta VFD parameters

  ## Changelog
  ### Added
  - Configurable VFD Modbus TCP/IP support alongside existing serial Modbus RTU control
  - RTU, TCP, and dry-run VFD transports
  - Unit tests for VFD command/register behavior

  ### Changed
  - Existing MQTT VFD commands now route through the high-level VFD driver while preserving serial defaults
